### PR TITLE
MNT public repo

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,6 +57,7 @@ install:
 build_script:
   # Build the compiled extension
   - "python setup.py build"
+  - "python -m pip install ."
 
 test_script:
   # Run the project tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -50,7 +50,8 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "python -m pip install -r requirements/win.txt"
+  # Currently, PyTorch for Windows is not on PyPI
+  - "python -m pip install -r requirements/win.txt -f https://download.pytorch.org/whl/torch_stable.html "
   - "python -m pip install -r requirements/dev.txt"
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -50,6 +50,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
+  - "python -m pip install -r requirements/win.txt"
   - "python -m pip install -r requirements/dev.txt"
 
 build_script:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DeepNOG is both faster and more accurate than assigning OGs with HMMER.
 
 The `deepnog` command line tool is written in Python 3.7+. 
 
-Current version: 1.0.2
+Current version: 1.0.4
 
 ## Installation guide
 
@@ -80,10 +80,10 @@ only.
 
 ## Neural network architectures supported
 
-*  DeepEncoding, for details, see the [research article](https://doi.org).
-(TODO: change to paper)
+*  DeepEncoding (=DeepNOG in the research article)
 
-## Required packages
+
+## Required packages (and minimum version)
 
 *  PyTorch 1.2.0
 *  NumPy 1.16.4
@@ -97,14 +97,4 @@ This research is supported by the Austrian Science Fund (FWF): P27703, P31988,
 and by the GPU grant program of Nvidia corporation.
 
 ## Citation
-If you use this software in a scientific project, please cite:
-
-```latex
-@article{Feldbauer2020,
-author  = {Roman Feldbauer and Lukas Gosch and Patrick Hyden and Thomas Rattei},
-title   = {DeepNOG: Fast and accurate protein orthologous group prediction},
-journal = {Projected: Bioinformatics},
-year    = {Projected: 2020},
-notes   = {\textit{in preparation}}
-}
-```
+A research article is currently in preparation.

--- a/deepnog/__init__.py
+++ b/deepnog/__init__.py
@@ -11,8 +11,8 @@ usage of the tool, the reader is referred to the documentation as well as
 deepnog.py.
 
 """
-from . import (dataset,
-               deepnog,
+from . import (client,
+               dataset,
                inference,
                io,
                models,
@@ -36,10 +36,10 @@ from . import (dataset,
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
-__all__ = ['dataset',
-           'deepnog',
+__all__ = ['client',
+           'dataset',
            'inference',
            'io',
            'models',

--- a/deepnog/client.py
+++ b/deepnog/client.py
@@ -3,7 +3,7 @@ Author: Lukas Gosch
 
 Date: 2019-10-18
 
-Usage: python deepnog.py --help
+Usage: python client.py --help
 
 Description:
 

--- a/deepnog/dataset.py
+++ b/deepnog/dataset.py
@@ -178,12 +178,6 @@ class ProteinIterator:
         If bigger or equal to two, the multi-process loading case happens.
     worker_id : int
         ID of worker this iterator belongs to
-
-    Attributes
-    ----------
-    sequence : namedtuple
-        Sequence data and metadata: All relevant information DeepNOG needs to
-        perform and store protein predictions for one protein sequence
     """
 
     def __init__(self, file_, aa_vocab, f_format,
@@ -225,6 +219,9 @@ class ProteinIterator:
         sequence : namedtuple
             Element at current + step + 1 position or start position.
             Furthermore prefixes element with unique sequential ID.
+            Contains sequence data and metadata, i.e. all relevant
+            information deepnog needs to perform and store predictions
+            for one protein sequence.
         """
         # Check if iterator has been positioned correctly.
         if self.pos is not None:

--- a/deepnog/models/__init__.py
+++ b/deepnog/models/__init__.py
@@ -4,9 +4,7 @@ Description:
     Network definitions (PyTorch modules)
 """
 
-from .deepencoding import (AminoAcidWordEmbedding,
-                           deepencoding,
-                           )
-__all__ = ['AminoAcidWordEmbedding',
-           'deepencoding',
+from . import deepencoding
+
+__all__ = ['deepencoding',
            ]

--- a/deepnog/models/deepencoding.py
+++ b/deepnog/models/deepencoding.py
@@ -152,18 +152,27 @@ class deepencoding(nn.Module):
         Returns
         -------
         out : Tensor, shape (batch_size, n_classes)
-            Confidence of sequence(s) beeing in one of the n_classes.
+            Confidence of sequence(s) being in one of the n_classes.
         """
+        # Fix type mismatch on Windows
+        x = x.long()
+
+        # Amino acid embedding
         x = self.encoding(x).permute(0, 2, 1).contiguous()
+
+        # Convolution with variable kernel sizes and adaptive max pooling
         max_pool_layer = []
         for i in range(self.n_conv_layers):
             x_conv = getattr(self, f'conv{i+1}')(x)
             x_conv = self.activation1(x_conv)
             x_conv = self.pool1(x_conv)
             max_pool_layer.append(x_conv)
+
         # Concatenate max_pooling output of different convolutions
         x = torch.cat(max_pool_layer, dim=1)
         x = x.view(-1, x.shape[1])
+
+        # Classification layer
         x = self.classification1(x)
         out = self.softmax(x)
         return out

--- a/deepnog/tests/test_cli.py
+++ b/deepnog/tests/test_cli.py
@@ -10,7 +10,7 @@ import pytest
 from unittest import mock
 import subprocess
 
-from deepnog.deepnog import main
+from deepnog.client import main
 
 test_file = Path(__file__).parent.absolute() / "data/test_deepencoding.faa"
 

--- a/doc/documentation/api/deepnog.client.rst
+++ b/doc/documentation/api/deepnog.client.rst
@@ -1,8 +1,8 @@
 
-:mod:`deepnog.deepnog`
+:mod:`deepnog.client`
 ======================
 
-.. automodule:: deepnog.deepnog
+.. automodule:: deepnog.client
    :members:
    :undoc-members:
    :inherited-members:

--- a/doc/documentation/documentation.rst
+++ b/doc/documentation/documentation.rst
@@ -14,8 +14,8 @@ This is the API documentation for ``deepnog``.
    :maxdepth: 2
    :caption: Modules and subpackages
 
+   client     <api/deepnog.client>
    dataset    <api/deepnog.dataset>
-   deepnog    <api/deepnog.deepnog>
    inference  <api/deepnog.inference>
    io         <api/deepnog.io>
    models     <api/deepnog.models>

--- a/requirements/win.txt
+++ b/requirements/win.txt
@@ -1,0 +1,1 @@
+torch>=1.2.0 -f https://download.pytorch.org/whl/torch_stable.html  # not on PyPI

--- a/requirements/win.txt
+++ b/requirements/win.txt
@@ -1,1 +1,1 @@
-torch>=1.2.0 -f https://download.pytorch.org/whl/torch_stable.html  # not on PyPI
+torch>=1.2.0+cpu

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setuptools.setup(
     },
     entry_points={
         'console_scripts': [
-            'deepnog = deepnog.deepnog:main'
+            'deepnog = deepnog.client:main'
         ]
     },
     classifiers=[


### PR DESCRIPTION
Prepare the repo for public status.
This enables us to switch on AppVeyor, RTD, and LGTM,
and upload the wheels to PyPI.
